### PR TITLE
Add support to equivalent subjects and open classes tabs

### DIFF
--- a/main.js
+++ b/main.js
@@ -69,5 +69,4 @@ if(SUBJECTS != null) {
       discoverTimeToSubjects(SUBJECTS[i].children[5].children[0].innerHTML);
   }
 }
-
-const 
+ 

--- a/main.js
+++ b/main.js
@@ -72,6 +72,13 @@ if(SUBJECTS != null) {
 
 //Estou na parte de se inscrever em disciplinas equivalentes
 if(EQUIVALENT_SUBJECTS != null) {
+  /*Se estiver na página de disciplinas equivalentes,
+    define o width da coluna de horário como 16%
+    para uma visualização melhor
+  */
+  if (EQUIVALENT_SUBJECTS.length != 0) {
+    document.getElementById('lista-turmas-curriculo').firstElementChild.firstElementChild.children[4].setAttribute('width', '16%');
+  }
   for(let i = 0; i<EQUIVALENT_SUBJECTS.length; i++) {
     /*Para cada linha de disciplina (EQUIVALENT_SUBJECTS[i]), 
       seleciona a coluna que contém o código de horário (children[6]),
@@ -86,6 +93,13 @@ if(EQUIVALENT_SUBJECTS != null) {
 
 //Estou na parte de se inscrever em disciplinas abertas
 if(OPEN_SUBJECTS != null) {
+  /*Se estiver na página de disciplinas abertas,
+    define o width da coluna de horário como 18%
+    para uma visualização melhor
+  */
+  if (OPEN_SUBJECTS.length != 0) {
+    document.getElementById('lista-turmas-extra').firstElementChild.firstElementChild.children[5].setAttribute('width', '18%');
+  }
   for(let i = 0; i<OPEN_SUBJECTS.length; i++) {
     /*Para cada linha de disciplina (OPEN_SUBJECTS[i]), 
       seleciona a coluna que contém o código de horário (children[7]),

--- a/main.js
+++ b/main.js
@@ -69,4 +69,17 @@ if(SUBJECTS != null) {
       discoverTimeToSubjects(SUBJECTS[i].children[5].children[0].innerHTML);
   }
 }
- 
+
+//Estou na parte de se inscrever em disciplinas equivalentes
+if(EQUIVALENT_SUBJECTS != null) {
+  for(let i = 0; i<EQUIVALENT_SUBJECTS.length; i++) {
+    /*Para cada linha de disciplina (EQUIVALENT_SUBJECTS[i]), 
+      seleciona a coluna que contém o código de horário (children[6]),
+      e dentro do <td> de horário, existe uma tag <label>,
+      logo é necessário descer mais um nível na árvore (children[0]) para
+      conseguir acessar o código com o horário da disciplina
+    */
+    EQUIVALENT_SUBJECTS[i].children[6].children[0].innerHTML = 
+      discoverTimeToSubjects(EQUIVALENT_SUBJECTS[i].children[6].children[0].innerHTML);
+  }
+}

--- a/main.js
+++ b/main.js
@@ -83,3 +83,17 @@ if(EQUIVALENT_SUBJECTS != null) {
       discoverTimeToSubjects(EQUIVALENT_SUBJECTS[i].children[6].children[0].innerHTML);
   }
 }
+
+//Estou na parte de se inscrever em disciplinas abertas
+if(OPEN_SUBJECTS != null) {
+  for(let i = 0; i<OPEN_SUBJECTS.length; i++) {
+    /*Para cada linha de disciplina (OPEN_SUBJECTS[i]), 
+      seleciona a coluna que contém o código de horário (children[7]),
+      e dentro do <td> de horário, existe uma tag <label>,
+      logo é necessário descer mais um nível na árvore (children[0]) para
+      conseguir acessar o código com o horário da disciplina
+    */
+    OPEN_SUBJECTS[i].children[7].children[0].innerHTML = 
+      discoverTimeToSubjects(OPEN_SUBJECTS[i].children[7].children[0].innerHTML);
+  }
+}

--- a/selects.js
+++ b/selects.js
@@ -35,6 +35,10 @@ const SUBJECTS = document.querySelectorAll('[id*="NívelTR"]');
 //As linhas (<tr>) de disciplinas tem um id nesse estilo -> cc_30847c_24803t_01s_TR
 const EQUIVALENT_SUBJECTS = document.querySelectorAll('[id*="_TR"]');
 
+//Seleciona elemento cujo id contenha turma_ e seja da tag tr
+//As linhas (<tr>) de disciplinas tem um id nesse estilo -> turma_142381TR
+const OPEN_SUBJECTS = document.querySelectorAll('tr[id*="turma_"]');
+
 const TIME_BOARD = {
   M1: "07:00 às 08:00",
   M2: "08:00 às 09:00",

--- a/selects.js
+++ b/selects.js
@@ -31,6 +31,10 @@ const SIGAA_BETA_SCHEDULE_TIME_HEADER = document.querySelector(
 //As linhas (<tr>) de disciplinas tem um id nesse estilo -> cc_29001t_05s_0º NívelTR
 const SUBJECTS = document.querySelectorAll('[id*="NívelTR"]');
 
+//Seleciona elemento cujo id contenha _TR
+//As linhas (<tr>) de disciplinas tem um id nesse estilo -> cc_30847c_24803t_01s_TR
+const EQUIVALENT_SUBJECTS = document.querySelectorAll('[id*="_TR"]');
+
 const TIME_BOARD = {
   M1: "07:00 às 08:00",
   M2: "08:00 às 09:00",


### PR DESCRIPTION
Fiz alguns ajustes no `width` da coluna de horário pois o horário ficava comprimido nas páginas de disciplinas equivalentes e de turmas abertas. Fiz alguns testes no Firefox e no Edge e não observei impactos negativos.